### PR TITLE
graphile-build-pg patchField changed.

### DIFF
--- a/src/PostgraphileNestedMutationsPlugin.js
+++ b/src/PostgraphileNestedMutationsPlugin.js
@@ -214,7 +214,7 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
           : inflection.createPayloadType(table),
       );
       const tableFieldName = isPgUpdateMutationField
-        ? inflection.patchField(table.name)
+        ? inflection.patchField(inflection.tableFieldName(table))
         : inflection.tableFieldName(table);
       const parsedResolveInfoFragment = parseResolveInfo(resolveInfo);
       const resolveData = getDataFromParsedResolveInfoFragment(parsedResolveInfoFragment, PayloadType);


### PR DESCRIPTION
The `patchField` name is not match the rule in latest graphile-build-pg, 
which now should get table field instead of use table.name. 
It will case the plural table name apply to the patchField with `s` but the real input name is not with `s`. 
see the following link as the reference. 

https://github.com/graphile/graphile-engine/blob/819da5ee9af613a020df5b2dd35ffb69877914e8/packages/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.js#L452