### PR TITLE
Nested mutation fails if parent row is not selected/updated

### DIFF
--- a/src/PostgraphileNestedConnectorsPlugin.js
+++ b/src/PostgraphileNestedConnectorsPlugin.js
@@ -77,7 +77,7 @@ module.exports = function PostGraphileNestedConnectorsPlugin(builder) {
           if (identifiers.length !== primaryKeys.length) {
             throw new Error('Invalid ID');
           }
-          where = sql.fragment`${sql.join(
+          where = sql.fragment`(${sql.join(
             primaryKeys.map(
               (key, idx) =>
                 sql.fragment`${sql.identifier(key.name)} = ${gql2pg(
@@ -87,10 +87,10 @@ module.exports = function PostGraphileNestedConnectorsPlugin(builder) {
                 )}`,
             ),
             ') and (',
-          )}`;
+          )})`;
         } else {
           const foreignPrimaryKeys = constraint.keyAttributes;
-          where = sql.fragment`${sql.join(
+          where = sql.fragment`(${sql.join(
             foreignPrimaryKeys.map(
               (k) => sql.fragment`
                 ${sql.identifier(k.name)} = ${gql2pg(
@@ -101,7 +101,7 @@ module.exports = function PostGraphileNestedConnectorsPlugin(builder) {
               `,
             ),
             ') and (',
-          )}`;
+          )})`;
         }
         const select = foreignKeys.map((k) => sql.identifier(k.name));
         const query = parentRow

--- a/src/PostgraphileNestedDeletersPlugin.js
+++ b/src/PostgraphileNestedDeletersPlugin.js
@@ -77,7 +77,7 @@ module.exports = function PostGraphileNestedDeletersPlugin(builder) {
           if (identifiers.length !== primaryKeys.length) {
             throw new Error('Invalid ID');
           }
-          where = sql.fragment`${sql.join(
+          where = sql.fragment`(${sql.join(
             primaryKeys.map(
               (key, idx) =>
                 sql.fragment`${sql.identifier(key.name)} = ${gql2pg(
@@ -87,10 +87,10 @@ module.exports = function PostGraphileNestedDeletersPlugin(builder) {
                 )}`,
             ),
             ') and (',
-          )}`;
+          )})`;
         } else {
           const foreignPrimaryKeys = constraint.keyAttributes;
-          where = sql.fragment`${sql.join(
+          where = sql.fragment`(${sql.join(
             foreignPrimaryKeys.map(
               (k) => sql.fragment`
                 ${sql.identifier(k.name)} = ${gql2pg(
@@ -101,7 +101,7 @@ module.exports = function PostGraphileNestedDeletersPlugin(builder) {
               `,
             ),
             ') and (',
-          )}`;
+          )})`;
         }
         const select = foreignKeys.map((k) => sql.identifier(k.name));
         const query = parentRow

--- a/src/PostgraphileNestedMutationsPlugin.js
+++ b/src/PostgraphileNestedMutationsPlugin.js
@@ -322,7 +322,7 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
               if (identifiers.length !== primaryKeys.length) {
                 throw new Error('Invalid ID');
               }
-              condition = sql.fragment`${sql.join(
+              condition = sql.fragment`(${sql.join(
                 table.primaryKeyConstraint.keyAttributes.map(
                   (key, idx) =>
                     sql.fragment`${sql.identifier(key.name)} = ${gql2pg(
@@ -332,7 +332,7 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                     )}`,
                 ),
                 ') and (',
-              )}`;
+              )})`;
             } catch (e) {
               debug(e);
               throw e;
@@ -486,7 +486,7 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                   await Promise.all(
                     updaterField.map(async (node) => {
                       const where = sql.fragment`
-                    ${sql.join(
+                    (${sql.join(
                       keys.map(
                         (k, i) =>
                           sql.fragment`${sql.identifier(k.name)} = ${sql.value(
@@ -494,7 +494,7 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                           )}`,
                       ),
                       ') and (',
-                    )}
+                    )})
                   `;
                       const updatedRow = await pgNestedTableUpdate({
                         nestedField,

--- a/src/PostgraphileNestedMutationsPlugin.js
+++ b/src/PostgraphileNestedMutationsPlugin.js
@@ -438,6 +438,11 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                       });
 
                       if (primaryKeys) {
+                        if (!connectedRow) {
+                          throw new Error(
+                            'Unable to update/select parent row.',
+                          );
+                        }
                         const rowKeyValues = {};
                         primaryKeys.forEach((col) => {
                           rowKeyValues[col.name] = connectedRow[col.name];
@@ -520,7 +525,7 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                   );
                 }),
             );
-            
+
             if (fieldValue.deleteOthers) {
               // istanbul ignore next
               if (!primaryKeys) {

--- a/src/PostgraphileNestedUpdatersPlugin.js
+++ b/src/PostgraphileNestedUpdatersPlugin.js
@@ -92,7 +92,7 @@ module.exports = function PostGraphileNestedUpdatersPlugin(builder) {
           if (identifiers.length !== primaryKeys.length) {
             throw new Error('Invalid ID');
           }
-          keyWhere = sql.fragment`${sql.join(
+          keyWhere = sql.fragment`(${sql.join(
             primaryKeys.map(
               (key, idx) =>
                 sql.fragment`${sql.identifier(key.name)} = ${gql2pg(
@@ -102,10 +102,10 @@ module.exports = function PostGraphileNestedUpdatersPlugin(builder) {
                 )}`,
             ),
             ') and (',
-          )}`;
+          )})`;
         } else {
           const foreignPrimaryKeys = constraint.keyAttributes;
-          keyWhere = sql.fragment`${sql.join(
+          keyWhere = sql.fragment`(${sql.join(
             foreignPrimaryKeys.map(
               (k) => sql.fragment`
                 ${sql.identifier(k.name)} = ${gql2pg(
@@ -116,7 +116,7 @@ module.exports = function PostGraphileNestedUpdatersPlugin(builder) {
               `,
             ),
             ') and (',
-          )}`;
+          )})`;
         }
 
         const patchField =


### PR DESCRIPTION
Hello,

There is an issue on nested mutation, if you do not have the right to update the parent row. You end up trying to access a column of undefined there https://github.com/mlipscombe/postgraphile-plugin-nested-mutations/blob/master/src/PostgraphileNestedMutationsPlugin.js#L443

Here is a quick way to reproduce (may not be working yet, I'm on it):

```sql
create table a (
  id integer not null PRIMARY,
  name text null
);
grant select, insert on a to :DATABASE_VISITOR;

create table b (
  id integer not null PRIMARY,
  name text null
  a integer null references a
);
create index on b (a);
grant select, insert on b to :DATABASE_VISITOR;

insert into b (1, 'test 1', null);
```

Then perform a graphql nested mutation by creating a new `a`, and trying to connect it to `b`. Since b cannot be updated, [pgNestedTableConnect](https://github.com/mlipscombe/postgraphile-plugin-nested-mutations/blob/d93dd446f806feb03e5f0d8af910dd44cf603335/src/PostgraphileNestedConnectorsPlugin.js#L133) will return undefined.

By the way, we create a `stable` branch, and tags `v1.1.0` (with fixes from #16, #24) and `v1.1.1` (`v1.1.0` + current commit) on our own repository, since that one does not seem maintained anymore. We have several people working on graphile at Sterblue, and are relying a lot on nested mutations plugin.