### PR TITLE
Improved details of error message when unable to update or select a parent row

### DIFF
--- a/src/PostgraphileNestedMutationsPlugin.js
+++ b/src/PostgraphileNestedMutationsPlugin.js
@@ -187,9 +187,6 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                     pgClient,
                   });
 
-                  if (!row) {
-                    throw new Error('invalid connect keys');
-                  }
 
                   foreignKeys.forEach((k, idx) => {
                     output[inflection.column(keys[idx])] = row[k.name];
@@ -479,11 +476,6 @@ module.exports = function PostGraphileNestedMutationPlugin(builder) {
                       });
 
                       if (primaryKeys) {
-                        if (!connectedRow) {
-                          throw new Error(
-                            'Unable to update/select parent row.',
-                          );
-                        }
                         const rowKeyValues = {};
                         primaryKeys.forEach((col) => {
                           rowKeyValues[col.name] = connectedRow[col.name];


### PR DESCRIPTION
I'm honestly not even sure this library is still maintained, so I may have wasted my time, but in case I didn't I made a patch that improves the error message I mentioned in #65.